### PR TITLE
Add TrendMicro deepsec log forwarding syslog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Requirements
 Red Hat Enterprise Linux 7.x, or derived Linux distribution such as CentOS 7,
 Scientific Linux 7, etc
 
+For TrendMicro provider to work with log_manager as expected
+user should have [TrendMicro DeepSecurity collection](https://galaxy.ansible.com/trendmicro/deepsec) installed
+
 Functions
 ---------
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An [Ansible](https://ansible.com) role to manage logs in many firewall devices.
 
 Current supported list of providers:
 * checkpoint
+* trendmicro
 
 Requirements
 ------------
@@ -34,6 +35,18 @@ Example Playbook
         syslog_server: 192.168.0.1
         checkpoint_server_name: test
         firewall_provider: checkpoint
+
+- hosts: trendmicro
+  connection: httpapi
+
+  tasks:
+    - include_role:
+        name: log_manager
+        tasks_from: forward_logs_to_syslog
+      vars:
+        syslog_server: 192.168.0.1
+        trendmicro_syslog_config_name: test
+        firewall_provider: trendmicro
 ```
 
 

--- a/tasks/providers/trendmicro/forward_logs_to_syslog.yaml
+++ b/tasks/providers/trendmicro/forward_logs_to_syslog.yaml
@@ -1,5 +1,5 @@
 - name: Enable sending TrendMicro DeepSecurity logs to syslog
-  syslog_config:
+  trendmicro.deepsec.syslog_config:
     state: present
     name: "{{ trendmicro_syslog_config_name }}"
     facility: local0
@@ -8,4 +8,4 @@
     server: "{{ syslog_server }}"
     port: 514
     transport: udp
-    description: Syslog Api request from Ansible
+    description: Syslog API request from Ansible

--- a/tasks/providers/trendmicro/forward_logs_to_syslog.yaml
+++ b/tasks/providers/trendmicro/forward_logs_to_syslog.yaml
@@ -1,0 +1,11 @@
+- name: Enable sending TrendMicro DeepSecurity logs to syslog
+  syslog_config:
+    state: present
+    name: "{{ trendmicro_syslog_config_name }}"
+    facility: local0
+    event_format: leef
+    direct: false
+    server: "{{ syslog_server }}"
+    port: 514
+    transport: udp
+    description: Syslog Api request from Ansible

--- a/tasks/providers/trendmicro/unforward_logs_to_syslog.yaml
+++ b/tasks/providers/trendmicro/unforward_logs_to_syslog.yaml
@@ -1,4 +1,4 @@
 - name:  Disable sending TrendMicro DeepSecurity logs to syslog
-  syslog_config:
+  trendmicro.deepsec.syslog_config:
     state: absent
     name: "{{ trendmicro_syslog_config_name }}"

--- a/tasks/providers/trendmicro/unforward_logs_to_syslog.yaml
+++ b/tasks/providers/trendmicro/unforward_logs_to_syslog.yaml
@@ -1,0 +1,4 @@
+- name:  Disable sending TrendMicro DeepSecurity logs to syslog
+  syslog_config:
+    state: absent
+    name: "{{ trendmicro_syslog_config_name }}"


### PR DESCRIPTION
Add TrendMicro deepsec log forwarding syslog support, ref: https://github.com/ansible-collections/trendmicro.deepsec/pull/2, I am expecting this PR to get merged max by tomorrow and once that's merged this added support should also start working as expected.

cc. @liquidat 